### PR TITLE
Change some obvious instances of hardcoded values of maxorb.

### DIFF
--- a/src/checkOrtho.f90
+++ b/src/checkOrtho.f90
@@ -19,8 +19,8 @@ subroutine checkOrtho (iorb1,psi,f4,wgt2,wk0)
   implicit none
   integer :: ibeg1,ibeg3,iorb1,iorb2,iorb3,jor,jor1,ngrid
 
-  integer, dimension(60) :: istp(60)
-  real (PREC), dimension(60) :: ovla,ovla1
+  integer, dimension(maxorb) :: istp
+  real (PREC), dimension(maxorb) :: ovla,ovla1
   real (PREC), dimension(*) :: psi,f4,wgt2,wk0
   real (PREC), external :: dot
 

--- a/src/commons8.f90
+++ b/src/commons8.f90
@@ -86,9 +86,9 @@ module commons8
 
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      character*8, dimension(60)  :: gut,bond,orbsym
-      character*8, dimension(240)  :: spin
-      character*8, dimension(300)  :: spn
+      character*8, dimension(maxorb)  :: gut,bond,orbsym
+      character*8, dimension(4*maxorb)  :: spin
+      character*8, dimension(5*maxorb)  :: spn
 
       integer :: nexchp,norb,nel,nexch
 
@@ -108,7 +108,7 @@ module commons8
       integer, dimension(10) :: nmu,ngsize,inpv,ibmu,iemu,ioffs,iorder,nmu_p,ngsize_p,ibmu_p,iemu_p,ioffs_p
       real (PREC), dimension(10) :: rgrid_p
       integer, dimension(20) :: i4b,i5b,i4e,i5e,i4si,i5si,i4ng,i5ng,iadext,iadnor,iadex1,iadex2,iadex3
-      integer, dimension(60) :: i1b,i2b,i1e,i2e,i1si,i2si,i1ng,i2ng,i1mu,i2mu,i3nexcp,ifix,iorn,inhyd,inhydlcao,&
+      integer, dimension(maxorb) :: i1b,i2b,i1e,i2e,i1si,i2si,i1ng,i2ng,i1mu,i2mu,i3nexcp,ifix,iorn,inhyd,inhydlcao,&
            nn,ll,mm,iocc,isymOrb,lock,ige,ihomo,iscforder,maxsororb,maxsorpot,itouch,iloop
 
       integer, dimension(120) :: lagraon

--- a/src/doSCF.f90
+++ b/src/doSCF.f90
@@ -23,7 +23,7 @@ subroutine doSCF (cw_sor,cw_orb,cw_coul,cw_exch,cw_suppl,cw_sctch)
 
   integer, dimension(*) :: cw_sor
 
-  real (PREC), dimension(60) :: demaxt
+  real (PREC), dimension(maxorb) :: demaxt
   real (PREC), dimension(*) ::  cw_orb,cw_coul,cw_exch,cw_suppl,cw_sctch
 
   logical :: stop_x2dhf

--- a/src/nuclder.f90
+++ b/src/nuclder.f90
@@ -28,7 +28,7 @@ subroutine nuclder(psi,e,f0,wgt1,wgt2,dermu,dernu,dznu,wk2,wk3,wk4,wk5)
   real (PREC), dimension(*) :: e,f0,wgt1,wgt2,dznu,wk2,wk3,wk4,wk5
   real (PREC), dimension(nni,*) :: psi,dermu,dernu
   real (PREC), dimension(6) :: dzmu
-  real (PREC), dimension(60) :: tderzorb1,tderzorb2,tderzorb3,tderzorb4
+  real (PREC), dimension(maxorb) :: tderzorb1,tderzorb2,tderzorb3,tderzorb4
   real (PREC), external :: factor
   iprt=0
 

--- a/src/ortho.f90
+++ b/src/ortho.f90
@@ -19,8 +19,8 @@ subroutine ortho (iorb1,psi,f4,wgt2,wk0)
   implicit none
   integer :: ibeg1,ibeg3,iorb1,iorb2,iorb3,ira,jor,jor1,ngrid
   real (PREC) :: ano
-  integer, dimension(60) :: index,istp
-  real (PREC), dimension(60) :: ovla,ovla1
+  integer, dimension(maxorb) :: index,istp
+  real (PREC), dimension(maxorb) :: ovla,ovla1
   real (PREC), dimension(*) :: psi,f4,wgt2,wk0
   real (PREC), external :: dot
 

--- a/src/params.f90
+++ b/src/params.f90
@@ -18,11 +18,11 @@ module params
   integer, parameter :: maxmu    = 2500
   integer, parameter :: maxbasis = 650
 
-
-! the following values should be left unchanged
+  ! the following values should be left unchanged, since the code
+  ! still has the values hardcoded in some routines!
   integer, parameter :: maxgrids = 1
   integer, parameter :: maxorb   = 60
-  integer, parameter :: maxmpole  = 8
+  integer, parameter :: maxmpole = 8
 
   character*10 :: formint,formfp,formfp64,formfp128
   data formint /'(10i15)  '/

--- a/src/prepGauss.f90
+++ b/src/prepGauss.f90
@@ -24,11 +24,13 @@ subroutine prepGauss
   integer :: i,ib,ibc,ibp,icent,icount,ifbo,jfbo,ilines,iorb,ipbasis,iprint0,iprint1,iprint2,istop, &
        l1,m1,m1abs,n1prim,n2prim,n3prim,nexpon,nfborb
 
-  integer, dimension(60) :: ifbord,ifdord
+  integer, dimension(maxorb) :: ifbord,ifdord
 
   real (PREC) :: d1
   real (PREC), dimension(maxbasis) :: ccoeff
-  real (PREC), dimension(0:60,0:maxbasis) :: excoeff
+  ! We can have up to 2x more orbitals in Gaussian than in the 2d
+  ! calculation because non-sigma orbitals appear in twos.
+  real (PREC), dimension(2*maxorb,maxbasis) :: excoeff
   real (PREC), external :: factor,factor2
 
   ! Orbital character

--- a/src/prepGaussCust.f90
+++ b/src/prepGaussCust.f90
@@ -30,13 +30,13 @@ subroutine prepGaussCust
   integer :: i,ib,ibc,ibpt,ibr,ibret,ibrett,ibt,icent,icentre,icount,idavid,ifbo,ilabel,ilines,iorb, &
        ipb,iprint0,iprint1,iprint2,iskip,j,k,l1,m1,m1abs,n1prim,n2prim,n3prim,nexpon,nfborb
 
-  integer, dimension(60) :: ifbord,ifdord
+  integer, dimension(maxorb) :: ifbord,ifdord
 
   character*3, dimension(maxbasis) :: conbt
   real (PREC) :: d1,excoeffm,excoeffp,expon,symthresh
   real (PREC), dimension(maxbasis) :: ibfres
   real (PREC), dimension(3,maxbasis) :: sexpon
-  real (PREC), dimension(0:60,0:maxbasis) :: excoeff
+  real (PREC), dimension(0:maxorb,0:maxbasis) :: excoeff
   real (PREC), external :: factor,factor2
 
   character*2 :: st
@@ -97,7 +97,7 @@ subroutine prepGaussCust
   !     program (one nonsigma finite difference orbital corresponds
   !     to two GAUSSIAN9x ones
 
-  do i=0,60
+  do i=0,maxorb
      do j=1,maxbasis
         excoeff(i,j)=0.0_PREC
      enddo

--- a/src/schedSOR.f90
+++ b/src/schedSOR.f90
@@ -19,8 +19,8 @@ subroutine schedsor
 
   implicit none
   integer :: i,iorb,inde,indemin,maxlevel,minlevel,nlevels
-  integer, dimension(60) :: index
-  real (PREC), dimension(60) :: endiff
+  integer, dimension(maxorb) :: index
+  real (PREC), dimension(maxorb) :: endiff
 
   if (mod(iscf,iepoch).eq.0) then
      i=iscf/iepoch

--- a/src/scheduler.f90
+++ b/src/scheduler.f90
@@ -3,6 +3,6 @@ module scheduler
 
   integer :: ibonus,iepoch,nepochs
   parameter (ibonus=3,iepoch=10,nepochs=5000)
-  integer, dimension(60) :: iorbiter
-  real (PREC), dimension(nepochs,60) ::  orbenergy,orbnorm
+  integer, dimension(maxorb) :: iorbiter
+  real (PREC), dimension(nepochs,maxorb) ::  orbenergy,orbnorm
 end module scheduler


### PR DESCRIPTION
Here I change some obvious instances of a hardcoded maxorb value.

There still remain quite a lot of hardcoded dimensions related to number of orbitals, especially in commons8.f90.