### PR TITLE
Rewrote Gaussian output parser to check the atoms and geometry.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,12 +3,12 @@
 add_executable(x2dhf blas.F90 card.f90 checkOrbSym.f90 checkOrtho.f90
 checkPot.f90 checkSym.f90 commons16.f90 commons8.f90 contrib.f90
 contriborbDFT.f90 contriborb.f90 coulAsymptCont.f90 coulAsympt.f90
-coulMCSOR.f90 coulMom.f90 coulSOR.f90 dftauxfun.f90 dftex.f90
-dgamit.f diffmu.f90 diffnu.f90 discret.f90 dointerp.f90
-dointerp_mu.f90 dointerp_nu.f90 doSCF.f90 doSOR.f90 Eab1DFT.f90
-Eab1HF.f90 Eab2DFT.f90 EabDFT.f90 Eab.f90 EaDFT.f90 Ea.f90
-eclyptot.f90 ecvwntot.f90 ehemsic.f90 es.f90 etotalDFT.f90 etotal.f90
-etotalGauss.f90 etotalOrb.f90 evalGauss.f90 exbe88.f90 exbe88sup.f90
+coulMCSOR.f90 coulMom.f90 coulSOR.f90 dftauxfun.f90 dftex.f90 dgamit.f
+diffmu.f90 diffnu.f90 discret.f90 dointerp.f90 dointerp_mu.f90
+dointerp_nu.f90 doSCF.f90 doSOR.f90 Eab1DFT.f90 Eab1HF.f90 Eab2DFT.f90
+EabDFT.f90 Eab.f90 EaDFT.f90 Ea.f90 eclyptot.f90 ecvwntot.f90
+ehemsic.f90 es.f90 etotalDFT.f90 etotal.f90 etotalGauss.f90
+etotalOrb.f90 evalGauss.f90 exbe88.f90 exbe88sup.f90
 exchAsymptCont.f90 exchAsympt.f90 exchMCSOR.f90 exchMom.f90
 exchSOR.f90 excont.f90 exint.f90 exocc.f90 expw86.f90 expw86sup.f90
 expw91.f90 expw91sup.f90 extinorg.f90 exxalpha.f90 factor2.f90
@@ -36,14 +36,15 @@ rfun.f90 rfun_int.f90 rheader.f90 rrec.f90 scf.f90 schedSOR.f90
 scheduler.f90 scmc.f90 separator.f90 setCi.f90 setCiOrb.f90
 setDefaults.f90 setmaxunit.f90 setOmega.f90 setOmegaOrb.f90
 setOmegaPot2.f90 setOmegaPot.f90 setPrecision.f90 slaterp.f90
-solver.f90 sor.f90 tail.f90 tden.f90 testn2f.f90 testnfng.f90 util.f90
-vcoul.f90 vexch.f90 vlpcoeff.f90 vpoly1q.f90 vpolyq.f90 wrec.f90
-wrecf.f90 writea128.f90 writea128f.f90 writea32.f90 writea32f.f90
-writea64.f90 writea64f.f90 writea.f90 writeDisk4dd.f90 writeDisk.f90
-wtdexch1.f90 wtdexch1f.f90 wtdexch.f90 wtdisk128.f90 wtdisk128f.f90
-wtdisk32.f90 wtdisk32f.f90 wtdisk64.f90 wtdisk64f.f90 wtdisknat.f90
-x2dhf.f90 zeroArray.f90 zeroArrays.f90 zgsz1.f90 zgsz1g.f90 zgsz2.f90
-zgsz2g.f90 zz1.f90 zz1g.f90 zz2.f90 zz2g.f90 )
+solver.f90 sor.f90 sort.f90 swap.f90 tail.f90 tden.f90 testn2f.f90
+testnfng.f90 util.f90 vcoul.f90 vexch.f90 vlpcoeff.f90 vpoly1q.f90
+vpolyq.f90 wrec.f90 wrecf.f90 writea128.f90 writea128f.f90
+writea32.f90 writea32f.f90 writea64.f90 writea64f.f90 writea.f90
+writeDisk4dd.f90 writeDisk.f90 wtdexch1.f90 wtdexch1f.f90 wtdexch.f90
+wtdisk128.f90 wtdisk128f.f90 wtdisk32.f90 wtdisk32f.f90 wtdisk64.f90
+wtdisk64f.f90 wtdisknat.f90 x2dhf.f90 zeroArray.f90 zeroArrays.f90
+zgsz1.f90 zgsz1g.f90 zgsz2.f90 zgsz2g.f90 zz1.f90 zz1g.f90 zz2.f90
+zz2g.f90 )
 
 # Install
 install (TARGETS x2dhf DESTINATION bin)

--- a/src/evalGauss.f90
+++ b/src/evalGauss.f90
@@ -7,15 +7,10 @@ module evalGauss
 contains
   subroutine evaluate(bf)
 
-    integer :: ic1, icen1, icen2, icen3, igp, imu, in, inioff, ipb, l1, m1
+    integer :: ic1, igp, imu, in, inioff, ipb, l1, m1
     real (PREC) :: costh1, d1, expt, fnorm, r1, z, psi1
     real (PREC), dimension(:,:) :: bf
     real (PREC), external :: plegendg
-
-    ! Center indices. Gaussian appears to flip these.
-    icen1=3
-    icen2=2
-    icen3=1
 
     ! Sanity check
     if(size(bf,1) .ne. nni*mxnmu .or. size(bf,2) .ne. npbasis) then
@@ -46,27 +41,25 @@ contains
              igp=inioff+in
 
              ! for each grid point, i.e. for (vmu(imu),vni(ini))
-             ! determine its distance |_r1| from the nuclei Z_1 and Z_2
-             ! and cosine of the polar angles costh1 and costh2 between
-             ! z axis and the vectors _r1 and _r2
-
-             ! rr=(r/2.0_PREC)*sqrt(vxisq(imu)+vetasq(in)-1.0_PREC)
+             ! determine its distance |r_i| from the nucleus Z_i and
+             ! cosine of the polar angle costh_i between the z axis
+             ! and the vector r_i
 
              z=(r/2.0_PREC)*vxi(imu)*veta(in)
 
-             if (ic1.eq.icen1) then
+             if (ic1.eq.1) then
                 ! Center on Z1
                 r1=(r/2.0_PREC)*(vxi(imu)+veta(in))
                 z=z+r/2.0_PREC
 
-             elseif (ic1.eq.icen3) then
+             elseif (ic1.eq.3) then
                 ! Center on Z2
                 r1=(r/2.0_PREC)*(vxi(imu)-veta(in))
                 z=z-r/2.0_PREC
 
-             elseif (ic1.eq.icen2) then
+             elseif (ic1.eq.2) then
                 ! Bond center
-                r1=sqrt(vxisq(imu)+vetasq(in)-1.0_PREC)*r/2.0_PREC
+                r1=(r/2.0_PREC)*sqrt(vxisq(imu)+vetasq(in)-1.0_PREC)
 
              else
                 write (*,*) 'invalid center ',ic1

--- a/src/initOrbPot.f90
+++ b/src/initOrbPot.f90
@@ -16,8 +16,7 @@ subroutine initOrbPot (cw_orb,cw_coul,cw_exch,cw_suppl,cw_sctch)
   use params
   use discret
   use commons8
-
-
+  use prepGauss
   implicit none
 
   integer :: iorb
@@ -162,7 +161,7 @@ subroutine initOrbPot (cw_orb,cw_coul,cw_exch,cw_suppl,cw_sctch)
      !  initial values of orbitals are provided by the GAUSSIAN program
 
      write(*,*) 'Initializing orbitals using GAUSSIAN output'
-     call prepGauss
+     call prepare_Gaussian
      call initGauss(cw_orb,cw_coul,cw_exch,cw_suppl(i4b(7)),cw_suppl(i4b(9)),cw_suppl(i4b(14)),cw_sctch(i5b(1)))
      idump=1
 

--- a/src/prepGauss.f90
+++ b/src/prepGauss.f90
@@ -1,6 +1,7 @@
 ! ***************************************************************************
 ! *                                                                         *
 ! *   Copyright (C) 1997-2010 Jacek Kobus <jkob@fizyka.umk.pl>              *
+! *   Copyright (C) 2018      Susi Lehtola                                  *
 ! *                                                                         *
 ! *   This program is free software; you can redistribute it and/or modify  *
 ! *   it under the terms of the GNU General Public License version 2 as     *
@@ -16,237 +17,445 @@
 !     The basis can contain functions defined on centres A and B and
 !     also at the bond centre.
 
-subroutine prepGauss
-  use params
-  use commons8
+module prepGauss
+contains
 
-  implicit none
-  integer :: i,ib,ibc,ibp,icent,icount,ifbo,jfbo,ilines,iorb,ipbasis,iprint0,iprint1,iprint2,istop, &
-       l1,m1,m1abs,n1prim,n2prim,n3prim,nexpon,nfborb
+  subroutine make_mapping(map,invmap,iZ,x,y,z,ncen)
+    use swap
+    use sort
+    implicit none
+    ! Gaussian center index mapping
+    integer, intent(out) :: map(3), invmap(3)
+    ! Nuclear charges
+    integer, intent(out) :: iZ(3)
+    ! x, y and z coordinates
+    double precision, intent(out) :: x(3), y(3), z(3)
+    ! Number of centers
+    integer, intent(out) :: ncen
 
-  integer, dimension(maxorb) :: ifbord,ifdord
+    ! Helper for i/o
+    character(80) :: line
+    ! Input center number
+    integer :: icen(3)
+    ! Atomic number
+    integer :: iZ0(3)
+    ! Atom type
+    integer :: itype(3)
+    ! X, Y and Z coordinates
+    double precision :: x0(3), y0(3), z0(3)
+    ! Is atom a dummy atom?
+    logical :: idum(3)
 
-  real (PREC) :: d1
-  real (PREC), dimension(maxbasis) :: ccoeff
-  ! We can have up to 2x more orbitals in Gaussian than in the 2d
-  ! calculation because non-sigma orbitals appear in twos.
-  real (PREC), dimension(2*maxorb,maxbasis) :: excoeff
-  real (PREC), external :: factor,factor2
+    ! Loop index, number of centers, read status, index of dummy atom, i/o status
+    integer :: i, j, stat
+    ! Gaussian94 format?
+    logical :: g94
 
-  ! Orbital character
-  real (PREC), dimension(0:3) :: ochar
-  real (PREC) :: ocharmax
-  integer :: ichar, icharmax
+    ! By default, assume G03 format
+    g94 = .false.
 
-  character*46 :: matchstr
+    ! Read four lines from input, which contain the separators
+    do i=1,4
+       read (7,'(A)') line
+       !write (*,*) 'Skipping line ' // line
+    end do
 
-  !     nforb  - number of finite basis (fb) set orbitals
-  !     ifbord - ordering of fb orbitals (0=sigma, 1=pi, 2=delta, etc)
-  !              the order is determined from the gaussian.out file
-  !     ifdord - ordering of finite difference (fd) orbitals
-  !              the order of fd orbitals is the same as in the input data
-  !              (phi orbitals first, then delta, etc)
+    ! Now, read the atoms
+    ncen=3
+    do i=1,3
+       read (7,'(A)') line
+       !write (*,*) 'Got line ' // line
+       ! Check we haven't gone too far
+       if(line .eq. ' ---------------------------------------------------------------------') then
+          ncen=i-1
+          exit
+       end if
+       ! Parse contents of line
+       if( g94 ) then
+          ! g94 doesn't have atom type
+          read (line,*,iostat=stat) icen(i), iZ0(i), x0(i), y0(i), z0(i)
+          if(stat.ne.0) stop 'Parsing error ' // line
+       else
+          read (line,*,iostat=stat) icen(i), iZ0(i), itype(i), x0(i), y0(i), z0(i)
+          if(stat .ne. 0) then
+             ! Try switching to g94 mode
+             g94=.true.
+             read (line,*,iostat=stat) icen(i), iZ0(i), x0(i), y0(i), z0(i)
+             if(stat.ne.0) stop 'Parsing error ' // line
+          end if
+       end if
+    end do
+    if(ncen .lt. 2) then
+       stop 'Not enough atoms!'
+    end if
 
-  iprint0=0
-  iprint1=0
-  iprint2=0
+    ! Initialize mapping
+    do i=1,3
+       map(i)=i
+       invmap(i)=i
+    end do
+    ! Construct mapping by sorting in increasing z
+    do i=1,ncen
+       do j=1,i-1
+          if(z0(map(i)) .lt. z0(map(j))) then
+             call iswap(map(i),map(j))
+          end if
+       end do
+    end do
+    ! Construct inverse mapping
+    do i=1,ncen
+       invmap(map(i))=i
+    end do
 
-  if (iprint(553).ne.0) iprint0=1
-  if (iprint(554).ne.0) iprint1=1
-  if (iprint(555).ne.0) iprint2=1
+    ! Figure out dummy atom index
+    if(g94) then
+       do i=1,ncen
+          idum(i)=iZ(i).eq.0
+       end do
+    else
+       do i=1,ncen
+          idum(i)=itype(i).ne.0
+       end do
+    end if
 
-  ! Open the GaussianXY output file
-  open(7,file='gaussian.out', status='old',form='formatted')
+    ! Dummy atoms have charge 0
+    do i=1,ncen
+       if(idum(i)) iZ0(i)=0
+    end do
 
-  do ilines=1,1000
-     read(7,1001,end=990,err=910) matchstr
-     ! Gaussian 94
-     if (matchstr.eq.' Basis set in the form of general basis input:') goto 900
-     ! Gaussian 03
-     if (matchstr.eq.' AO basis set in the form of general basis inp') goto 900
-  enddo
-  write(*,*) 'prepGauss: '
-  write(*,*) ' "AO basis set in the form of general basis input not found in GAUSSIANxy output file'
-  stop 'prepGauss'
-00900 continue
+    ! Give output in x2dhf order
+    call rsort(x0,x,map)
+    call rsort(y0,y,map)
+    call rsort(z0,z,map)
+    call isort(iZ0,iZ,map)
+  end subroutine make_mapping
 
-  ipbasis=1
-  npbasis=0
+  subroutine read_basis(nprim,nexpon,npbasis)
+    implicit none
+    integer, intent(out) :: nprim(3), nexpon, npbasis
+    integer :: ibc, ibp, istop, ncen
 
-  !     start extracting data from the output
+    !     start extracting data from the output
+    !     ibc counts contracted basis functions
+    !     ibp counts primitive basis functions
+    !     n1prim - number of primitive gaussian function at the centre A
+    !     n3prim - number of primitive gaussian function at the centre B
+    !     n2prim - number of primitive gaussian function at the bond centre
 
-  !     ibc counts contracted basis functions
-  !     ibp counts primitive basis functions
-  !     n1prim - number of primitive gaussian function at the centre A
-  !     n3prim - number of primitive gaussian function at the centre B
-  !     n2prim - number of primitive gaussian function at the bond centre
+    npbasis=0
+    ibc=0
+    ibp=0
+    nprim=0
+    ncen=1
 
-  ibc=0
-  ibp=0
-  n1prim=0
-  n2prim=0
-  n3prim=0
-  call rexponents(ibc,ibp,istop)
-  n1prim=ibp
-  if (istop.eq.0) then
-     call rexponents(ibc,ibp,istop)
-     n3prim=ibp-n1prim
-     if (istop.eq.0) then
-        icent=2
-        call rexponents(ibc,ibp,istop)
-        n2prim=ibp-n3prim-n1prim
-     endif
-  endif
+    ! Read basis on 1st center
+    call rexponents(ibc,ibp,istop)
+    nprim(1)=ibp
+    if (istop.eq.0) then
+       ncen=ncen+1
+       ! Read basis on 2nd center
+       call rexponents(ibc,ibp,istop)
+       nprim(2)=ibp-sum(nprim)
+       if (istop.eq.0) then
+          ncen=ncen+1
+          ! Read basis on 3rd center
+          call rexponents(ibc,ibp,istop)
+          nprim(3)=ibp-sum(nprim)
+       endif
+    endif
 
+    ! Store number of functions and primitives
+    nexpon=ibc
+    npbasis=ibp
+  end subroutine read_basis
+
+  subroutine prepare_Gaussian
+    use discret, only : z1, z2, r
+    use params
+    use commons8
+    implicit none
+    integer :: i,ib,ibc,ibp,icount,ifbo,jfbo,ilines,iorb,iprint0,iprint1,iprint2, &
+         l1,m1,m1abs,nexpon,nfborb
+
+    integer, dimension(maxorb) :: ifbord,ifdord
+
+    real (PREC) :: d1
+    real (PREC), dimension(maxbasis) :: ccoeff
+    ! We can have up to 2x more orbitals in Gaussian than in the 2d
+    ! calculation because non-sigma orbitals appear in twos.
+    real (PREC), dimension(2*maxorb,maxbasis) :: excoeff
+    real (PREC), external :: factor, factor2
+
+    ! Orbital character
+    real (PREC), dimension(0:3) :: ochar
+    real (PREC) :: ocharmax
+    integer :: ichar, icharmax
+
+    character*46 :: matchstr
+
+    ! Gaussian center index
+    integer :: map(3), invmap(3)
+    ! Nuclear charges
+    integer :: iZ(3)
+    ! x, y and z coordinates
+    double precision :: x(3), y(3), z(3)
+    ! Number of centers
+    integer :: ncen
+
+    ! Number of primitives on the centers
+    integer :: nprim(3)
+    ! Running index
+    integer :: ibf
+    ! Target atom
+    integer :: itgt
+
+    ! Basis function start and end
+    integer :: bfstart(3), bfend(3)
+    ! Found atoms and basis?
+    logical :: atoms_found, basis_found
+
+    !     nforb  - number of finite basis (fb) set orbitals
+    !     ifbord - ordering of fb orbitals (0=sigma, 1=pi, 2=delta, etc)
+    !              the order is determined from the gaussian.out file
+    !     ifdord - ordering of finite difference (fd) orbitals
+    !              the order of fd orbitals is the same as in the input data
+    !              (phi orbitals first, then delta, etc)
+
+    iprint0=0
+    iprint1=0
+    iprint2=0
+
+    if (iprint(553).ne.0) iprint0=1
+    if (iprint(554).ne.0) iprint1=1
+    if (iprint(555).ne.0) iprint2=1
+
+    ! Open the GaussianXY output file
+    open(7,file='gaussian.out', status='old',form='formatted')
+
+    atoms_found = .false.
+    basis_found = .false.
+
+    do ilines=1,100000
+       read(7,1001,end=990,err=910) matchstr
+
+       ! Gaussian 94 or 03/09/16
+       if (matchstr.eq.'                         Standard orientation:' .or. &
+            matchstr.eq.'                          Input orientation:') then
+          call make_mapping(map,invmap,iZ,x,y,z,ncen)
+          atoms_found = .true.
+       end if
+       if (matchstr.eq.' Basis set in the form of general basis input:' .or. &
+            matchstr.eq.' AO basis set in the form of general basis inp') then
+          call read_basis(nprim,nexpon,npbasis)
+          basis_found = .true.
+          exit
+       end if
+    enddo
 00910 continue
+    if (.not. atoms_found) then
+       stop 'Could not find system in GAUSSIANxy output file.'
+    end if
+    if (.not. basis_found) then
+       stop 'Could not find basis in GAUSSIANxy output file. Did you remember to specify gfinput?'
+    end if
 
-  nexpon=ibc
-  npbasis=ibp
-  write(*,1140) nexpon,npbasis,n1prim,n2prim,n3prim
+    close(7)
 
-  close(7)
+    ! Check atoms are on z axis
+    do i=1,ncen
+       if(abs(x(i)) .gt. epsilon(x(i)) .or. abs(y(i)) .gt. epsilon(y(i))) then
+          stop 'Atoms are not on z axis in Gaussian output'
+       end if
+    end do
 
-  open(7,file='gaussian.pun', status='old',form='formatted')
+    ! If we have three atoms, then the middle one must be a dummy
+    if(ncen==3 .and. iZ(2).ne.0) then
+       stop 'Bond-center atom must be a dummy!'
+    end if
+    ! Check charges are correct
+    if(abs(z1-iZ(1)).gt.precis) then
+       write (*,'(A,F4.1,A,I3)') 'z1=',z1,', iZ(1)=',iZ(1)
+       stop "Gaussian calculation is inconsistent with x2dhf for atom on the left"
+    end if
+    if(abs(z2-iZ(ncen)).gt.precis) then
+       write (*,'(A,F4.1,A,I1,A,I3)') 'z2=',z2,', iZ(',ncen,')=',iZ(ncen)
+       stop "Gaussian calculation is inconsistent with x2dhf for atom on the right"
+    end if
 
-  !  read(7,1001,end=991,err=992) matchstr
-  !    read(7,'(a8)',end=991,err=992) matchstr
-  read(7,*) matchstr
+    ! Check bond length is correct
+    if( abs((z(ncen)-z(1))/bohr2ang - r) .gt. 1e-6*r ) then
+       write (*,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+       write (*,*) '! Warning: bond distance mismatch detected in Gaussian calculation !'
+       write (*,'(A,F11.6,A,F11.6,A)') ' !  bond lengths: Gaussian ',(z(ncen)-z(1))/bohr2ang,' a.u., x2dhf ',r,' a.u. !'
+       write (*,*) '!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!'
+    end if
 
-  !     start extracting basis set expansion coefficients from
-  !     gaussian94.pun file
+    ! Form basis set table
+    bfstart=0
+    bfend=0
+    ibf=1
 
-  !     determine number of molecular orbitals as defined in the GAUSSIAN9x
-  !     program (one nonsigma finite difference orbital corresponds
-  !     to two GAUSSIAN9x ones
+    ! In the gaussian output, we have the functions on centers 1, 2,
+    ! and 3 in that order. In x2dhf this corresponds to icen(1),
+    ! icen(2) and icen(3).
+    do i=1,ncen
+       if(nprim(i).gt.0) then
+          ! Target center is
+          itgt=invmap(i)
+          ! In the case of two centers, we must have just the lhs and
+          ! rhs atom.
+          if(ncen.eq.2 .and. itgt.eq.2) itgt=3
+          bfstart(itgt)=ibf
+          bfend(itgt)=ibf+nprim(i)-1
+          ibf=ibf+nprim(i)
+       end if
+    end do
 
-  nfborb=0
-  do iorb=1,norb
-     ifdord(iorb)=mm(iorb)
-     ! write (*,*) 'fd orbital ',iorb,' m=',mm(iorb)
-     if (mm(iorb).eq.0) then
-        nfborb=nfborb+1
-     else
-        nfborb=nfborb+2
-     endif
-  enddo
+    write (*,'(A,I3,A,I3)') ' Center on the left   houses basis functions ',bfstart(1),'-',bfend(1)
+    if((bfend(2)-bfstart(2)).gt.0) then
+       write (*,'(A,I3,A,I3)') ' Center on the middle houses basis functions ',bfstart(2),'-',bfend(2)
+    end if
+    write (*,'(A,I3,A,I3)') ' Center on the right  houses basis functions ',bfstart(3),'-',bfend(3)
 
-  write(*,1142) norb,nfborb
+    open(7,file='gaussian.pun', status='old',form='formatted')
 
-  ! Retrieve expansion coefficients of the contracted gaussians
-  if (iprint1.ne.0) then
-     print *,'no. of basis function  no. of exp. coeff.'
-     do ibp=1,npbasis
-        ibc=ixref(ibp)
-     enddo
-  endif
+    !  read(7,1001,end=991,err=992) matchstr
+    !    read(7,'(a8)',end=991,err=992) matchstr
+    read(7,*) matchstr
 
-  do ifbo=1,nfborb
-     ! Read the MO coefficients
-     read(7,1011,end=991,err=992)
-     do ibc=1,nexpon,5
-        read(7,1012) (ccoeff(ibc+i),i=0,4)
-     enddo
+    !     start extracting basis set expansion coefficients from
+    !     gaussian94.pun file
 
-     ! Transform expansion coefficients of the contracted gaussians
-     ! into coefficients of primitive gaussians
-     do ibp=1,npbasis
-        ibc=ixref(ibp)
-        excoeff(ifbo,ibp)=ccoeff(ibc)*coeff(ibp)
-     enddo
-  enddo
+    !     determine number of molecular orbitals as defined in the GAUSSIAN9x
+    !     program (one nonsigma finite difference orbital corresponds
+    !     to two GAUSSIAN9x ones
 
-  ! Prepare expansion coefficients of a molecular orbital in the basis
-  ! set of primitive gaussian functions
-  do ib=1,npbasis
-     if (ib.le.n1prim) icent=1
-     if (ib.gt.n1prim.and.ib.le.(n1prim+n2prim)) icent=2
-     if (ib.gt.(n1prim+n2prim).and.ib.le.(n1prim+n2prim+n3prim)) icent=3
-     icgau(ib)=icent
-     !     write(*,1050) ib,ixref(ib),lprim(ib),mprim(ib),icgau(ib),primexp(ib)
-  end do
+    nfborb=0
+    do iorb=1,norb
+       ifdord(iorb)=mm(iorb)
+       ! write (*,*) 'fd orbital ',iorb,' m=',mm(iorb)
+       if (mm(iorb).eq.0) then
+          nfborb=nfborb+1
+       else
+          nfborb=nfborb+2
+       endif
+    enddo
 
-  ! Determine symmetry of GAUSSIANxy molecular orbitals
-  do ifbo=1,nfborb
-     ! Reset orbital character
-     ochar = 0.0
-     ! Compute orbital character checksum
-     do ib=1,npbasis
-        ochar(abs(mprim(ib))) = ochar(abs(mprim(ib))) + excoeff(ifbo,ib)**2
-     end do
-     ! Determine orbital symmetry from maximum
-     icharmax = 0
-     ocharmax = ochar(icharmax)
-     do ichar=1,3
-        if(ochar(ichar) > ocharmax) then
-           icharmax=ichar
-           ocharmax=ochar(icharmax)
-        end if
-     end do
-     ifbord(ifbo)=icharmax
-     ! write (*,*) 'fb orbital ',ifbo,' symmetry is ',icharmax
-  end do
+    write(*,1142) norb,nfborb
 
-  ! Initialize memory
-  do iorb=1,norb
-     do ib=1,npbasis
-        primcoef(iorb,ib)=0.0_PREC
-     end do
-  end do
+    ! Retrieve expansion coefficients of the contracted gaussians
+    if (iprint1.ne.0) then
+       print *,'no. of basis function  no. of exp. coeff.'
+       do ibp=1,npbasis
+          ibc=ixref(ibp)
+       enddo
+    endif
 
-  ! Associate finite basis orbitals with the corresponding fd ones
-  do iorb=1,norb
-     do ifbo=nfborb,1,-1
-        icount=0
-        ! Check if orbital characters match
-        if (ifdord(iorb).eq.ifbord(ifbo)) then
-           !           write (*,'(A,I3,A,I3)') 'Orbital ',iorb,' corresponds to Gaussian orbital ',ifbo
-           do ib=1,npbasis
-              primcoef(iorb,ib)=excoeff(ifbo,ib)
-           enddo
-           ! If this is not a sigma orbital, we need to zero out the degenerate orbital as well.
-           if (ifbord(ifbo).gt.0) then
-              do jfbo=ifbo-1,1,-1
-                 if(ifbord(ifbo) .eq. ifbord(jfbo)) then
-                    ifbord(jfbo)=-1
-                    exit
-                 end if
-              end do
-           end if
-           ! Reset orbital characters so that they'll be skipped next iteration
-           ifbord(ifbo)=-1
-           ifdord(iorb)=-2
-        endif
-     enddo
-  enddo
+    do ifbo=1,nfborb
+       ! Read the MO coefficients
+       read(7,1011,end=991,err=992)
+       do ibc=1,nexpon,5
+          read(7,1012) (ccoeff(ibc+i),i=0,4)
+       enddo
 
-  ! Calculate normalization factors
-  do ib=1,npbasis
-     d1=primexp(ib)
-     l1=lprim  (ib)
-     m1=mprim  (ib)
-     m1abs=abs(m1)
-     ! Normalization for the radial part
-     fngau2(ib)=( d1**(2*l1+3) * 2.0_PREC**(4*l1+7)/pii/(factor2(2*l1+1))**2)**0.250_PREC
-     ! Normalization for the angular part (spherical harmonic)
-     shngau(ib)=(-1)**m1 * sqrt( ((2*l1+1)*factor(l1-m1abs)) / (4.0_PREC*pii*factor(l1+m1abs)) )
-  enddo
+       ! Transform expansion coefficients of the contracted gaussians
+       ! into coefficients of primitive gaussians
+       do ibp=1,npbasis
+          ibc=ixref(ibp)
+          excoeff(ifbo,ibp)=ccoeff(ibc)*coeff(ibp)
+       enddo
+    enddo
 
-  return
+    ! Assign centers of basis functions
+    icgau=-1
+    do ib=1,npbasis
+       do i=1,3
+          if(ib .ge. bfstart(i) .and. ib .le. bfend(i)) icgau(ib)=i
+       end do
+       if(icgau(ib) .eq. -1) then
+          write (*,*) 'Could not assign center for basis function ',ib
+          stop
+       end if
+    end do
+
+    ! Determine symmetry of GAUSSIANxy molecular orbitals
+    do ifbo=1,nfborb
+       ! Reset orbital character
+       ochar = 0.0
+       ! Compute orbital character checksum
+       do ib=1,npbasis
+          ochar(abs(mprim(ib))) = ochar(abs(mprim(ib))) + excoeff(ifbo,ib)**2
+       end do
+       ! Determine orbital symmetry from maximum
+       icharmax = 0
+       ocharmax = ochar(icharmax)
+       do ichar=1,3
+          if(ochar(ichar) > ocharmax) then
+             icharmax=ichar
+             ocharmax=ochar(icharmax)
+          end if
+       end do
+       ifbord(ifbo)=icharmax
+       !write (*,'(A,I2,A,4F8.4)') 'fb orbital ',ifbo,' symmetry is ',ochar
+    end do
+
+    ! Initialize memory
+    do iorb=1,norb
+       do ib=1,npbasis
+          primcoef(iorb,ib)=0.0_PREC
+       end do
+    end do
+
+    ! Associate finite basis orbitals with the corresponding fd ones
+    do iorb=1,norb
+       do ifbo=nfborb,1,-1
+          icount=0
+          ! Check if orbital characters match
+          if (ifdord(iorb).eq.ifbord(ifbo)) then
+             !write (*,'(A5,A,I3,A,I3)') bond(iorb),' orbital ',iorb,' corresponds to Gaussian orbital ',ifbo
+             do ib=1,npbasis
+                primcoef(iorb,ib)=excoeff(ifbo,ib)
+             enddo
+             ! If this is not a sigma orbital, we need to zero out the degenerate orbital as well.
+             if (ifbord(ifbo).gt.0) then
+                do jfbo=ifbo-1,1,-1
+                   if(ifbord(ifbo) .eq. ifbord(jfbo)) then
+                      ifbord(jfbo)=-1
+                      exit
+                   end if
+                end do
+             end if
+             ! Reset orbital characters so that they'll be skipped next iteration
+             ifbord(ifbo)=-1
+             ifdord(iorb)=-2
+          endif
+       enddo
+    enddo
+
+    ! Calculate normalization factors
+    do ib=1,npbasis
+       d1=primexp(ib)
+       l1=lprim  (ib)
+       m1=mprim  (ib)
+       m1abs=abs(m1)
+       ! Normalization for the radial part
+       fngau2(ib)=( d1**(2*l1+3) * 2.0_PREC**(4*l1+7)/pii/(factor2(2*l1+1))**2)**0.250_PREC
+       ! Normalization for the angular part (spherical harmonic)
+       shngau(ib)=(-1)**m1 * sqrt( ((2*l1+1)*factor(l1-m1abs)) / (4.0_PREC*pii*factor(l1+m1abs)) )
+    enddo
+
+    return
 00990 print *,'PREPGAUSS: end of file encountered when reading gaussian.out'
-  stop
+    stop
 00991 print *,'PREPGAUSS: end of file encountered when reading gaussian.pun'
-  stop
+    stop
 00992 print *,'PREPGAUSS: error encountered when reading gaussian.pun'
-  stop "prepGauss"
+    stop "prepGauss"
 
 01001 format(a46)
 01011 format(15x,e15.8)
 01012 format(5e15.8)
-!01050 format(5i5,e15.8)
-01140 format(/15x,i4,' exponents ',                         &
-       /15x,i4,' primitive basis functions ',      &
-       /15x,i4,' primitives on centre 1'           &
-       /15x,i4,' primitives on centre 2'           &
-       /15x,i4,' primitives on centre 3'/)
+    !01050 format(5i5,e15.8)
 01142 format(15x,i4,' finite difference orbitals',/15x,i4,' finite basis set orbitals'/)
-end subroutine prepGauss
+  end subroutine prepare_Gaussian
+end module prepGauss

--- a/src/sort.f90
+++ b/src/sort.f90
@@ -1,0 +1,38 @@
+! ***************************************************************************
+! *                                                                         *
+! *   Copyright (C) 2018 Susi Lehtola                                       *
+! *                                                                         *
+! *   This program is free software; you can redistribute it and/or modify  *
+! *   it under the terms of the GNU General Public License version 2 as     *
+! *   published by the Free Software Foundation.                            *
+! *                                                                         *
+! ***************************************************************************
+module sort
+  use params, only : PREC
+  implicit none
+
+contains
+
+  subroutine isort(x,y,map)
+    integer, intent(in) :: x(:)
+    integer, intent(out) :: y(:)
+    integer, intent(in) :: map(:)
+    integer :: i
+    
+    do i=1,size(y)
+       y(i)=x(map(i))
+    end do
+  end subroutine isort
+
+  subroutine rsort(x,y,map)
+    real(PREC), intent(in) :: x(:)
+    real(PREC), intent(out) :: y(:)
+    integer, intent(in) :: map(:)
+    integer :: i
+    
+    do i=1,size(y)
+       y(i)=x(map(i))
+    end do
+  end subroutine rsort
+end module sort
+

--- a/src/swap.f90
+++ b/src/swap.f90
@@ -1,0 +1,32 @@
+! ***************************************************************************
+! *                                                                         *
+! *   Copyright (C) 2018 Susi Lehtola                                       *
+! *                                                                         *
+! *   This program is free software; you can redistribute it and/or modify  *
+! *   it under the terms of the GNU General Public License version 2 as     *
+! *   published by the Free Software Foundation.                            *
+! *                                                                         *
+! ***************************************************************************
+module swap
+  use params, only : PREC
+  implicit none
+contains
+
+  subroutine iswap(x,y)
+    integer, intent(inout) :: x, y
+    integer :: t
+
+    t=x
+    x=y
+    y=t
+  end subroutine iswap
+
+  subroutine rswap(x,y)
+    real(PREC), intent(inout) :: x, y
+    real(PREC) :: t
+
+    t=x
+    x=y
+    y=t
+  end subroutine rswap
+end module swap


### PR DESCRIPTION
When you run Gaussian, the program may or may not flip the orientation of the atoms ("Standard orientation"). This pull request implements code that does multiple sanity checks for the geometry of the system. The nuclear charges and bond length have to match x2dhf's input.

While mid-bond functions are supported in this version of the code, they don't appear to be working 100%. IMHO mid-bond functions shouldn't be necessary, since the Gaussian basis calculation will anyhow give a "wrong" solution. Just using a bigger atomic basis set will give you a better initial guess.